### PR TITLE
SOCKS 5 proxy support

### DIFF
--- a/src/main/java/com/ircclouds/irc/api/AbstractIRCSession.java
+++ b/src/main/java/com/ircclouds/irc/api/AbstractIRCSession.java
@@ -119,7 +119,7 @@ public abstract class AbstractIRCSession implements IIRCSession
 			_ctx = ((SecureIRCServer) aServer).getSSLContext();
 		}
 		
-		if (conn.open(aServer.getHostname(), aServer.getPort(), _ctx))
+		if (conn.open(aServer.getHostname(), aServer.getPort(), _ctx, aServer.getProxy()))
 		{
 			if (!daemon.isAlive())
 			{

--- a/src/main/java/com/ircclouds/irc/api/AbstractIRCSession.java
+++ b/src/main/java/com/ircclouds/irc/api/AbstractIRCSession.java
@@ -119,7 +119,7 @@ public abstract class AbstractIRCSession implements IIRCSession
 			_ctx = ((SecureIRCServer) aServer).getSSLContext();
 		}
 		
-		if (conn.open(aServer.getHostname(), aServer.getPort(), _ctx, aServer.getProxy()))
+		if (conn.open(aServer.getHostname(), aServer.getPort(), _ctx, aServer.getProxy(), aServer.isResolveByProxy()))
 		{
 			if (!daemon.isAlive())
 			{

--- a/src/main/java/com/ircclouds/irc/api/comms/IConnection.java
+++ b/src/main/java/com/ircclouds/irc/api/comms/IConnection.java
@@ -7,7 +7,7 @@ import javax.net.ssl.*;
 
 public interface IConnection
 {
-	boolean open(String aHostname, int aPort, SSLContext aContext, Proxy aProxy) throws IOException;
+	boolean open(String aHostname, int aPort, SSLContext aContext, Proxy aProxy, boolean resolveByProxy) throws IOException;
 	
 	void close() throws IOException;
 

--- a/src/main/java/com/ircclouds/irc/api/comms/IConnection.java
+++ b/src/main/java/com/ircclouds/irc/api/comms/IConnection.java
@@ -1,12 +1,13 @@
 package com.ircclouds.irc.api.comms;
 
 import java.io.*;
+import java.net.*;
 
 import javax.net.ssl.*;
 
 public interface IConnection
 {
-	boolean open(String aHostname, int aPort, SSLContext aContext) throws IOException;
+	boolean open(String aHostname, int aPort, SSLContext aContext, Proxy aProxy) throws IOException;
 	
 	void close() throws IOException;
 

--- a/src/main/java/com/ircclouds/irc/api/comms/SSLSocketChannelConnection.java
+++ b/src/main/java/com/ircclouds/irc/api/comms/SSLSocketChannelConnection.java
@@ -42,16 +42,20 @@ public class SSLSocketChannelConnection implements IConnection
 		cipherRecvBuffer = ByteBuffer.allocate(sslEngine.getSession().getPacketBufferSize());
 		appRecvBuffer = ByteBuffer.allocate(sslEngine.getSession().getApplicationBufferSize());
 
+		final InetSocketAddress address;
 		if (aProxy != null && aProxy.type() == Proxy.Type.SOCKS)
 		{
+			// FIXME how to determine whether to resolve immediately or use SOCKS5 proxy resolve feature
 			sChannel = new ProxiedSocketChannel(aProxy);
+			address = InetSocketAddress.createUnresolved(aHostname, aPort);
 		}
 		else
 		{
 			// Configured to not use a proxy, using the original SocketChannel.
 			sChannel = SocketChannel.open();
+			address = new InetSocketAddress(aHostname, aPort);
 		}
-		return sChannel.connect(new InetSocketAddress(aHostname, aPort));
+		return sChannel.connect(address);
 	}
 
 	@Override

--- a/src/main/java/com/ircclouds/irc/api/comms/SSLSocketChannelConnection.java
+++ b/src/main/java/com/ircclouds/irc/api/comms/SSLSocketChannelConnection.java
@@ -95,15 +95,18 @@ public class SSLSocketChannelConnection implements IConnection
 	{
 		try
 		{
-			if (!sslEngine.isOutboundDone())
+			if (sChannel.isConnected())
 			{
-				sslEngine.closeOutbound();
-				doAnyPendingHandshake();
-			}
-			else if (!sslEngine.isInboundDone())
-			{
-				sslEngine.closeInbound();
-				processHandshake();
+				if (!sslEngine.isOutboundDone())
+				{
+					sslEngine.closeOutbound();
+					doAnyPendingHandshake();
+				}
+				else if (!sslEngine.isInboundDone())
+				{
+					sslEngine.closeInbound();
+					processHandshake();
+				}
 			}
 		}
 		catch (IOException aExc)

--- a/src/main/java/com/ircclouds/irc/api/comms/SSLSocketChannelConnection.java
+++ b/src/main/java/com/ircclouds/irc/api/comms/SSLSocketChannelConnection.java
@@ -29,7 +29,7 @@ public class SSLSocketChannelConnection implements IConnection
 	private int remaingUnwraps;
 
 	@Override
-	public boolean open(String aHostname, int aPort, SSLContext aContext, Proxy aProxy) throws IOException
+	public boolean open(String aHostname, int aPort, SSLContext aContext, Proxy aProxy, boolean resolveByProxy) throws IOException
 	{
 		sslEngine  = aContext != null ? aContext.createSSLEngine(aHostname, aPort) : getDefaultSSLContext().createSSLEngine(aHostname, aPort);			
 		sslEngine.setNeedClientAuth(false);
@@ -45,9 +45,15 @@ public class SSLSocketChannelConnection implements IConnection
 		final InetSocketAddress address;
 		if (aProxy != null && aProxy.type() == Proxy.Type.SOCKS)
 		{
-			// FIXME how to determine whether to resolve immediately or use SOCKS5 proxy resolve feature
 			sChannel = new ProxiedSocketChannel(aProxy);
-			address = InetSocketAddress.createUnresolved(aHostname, aPort);
+			if (resolveByProxy)
+			{
+				address = InetSocketAddress.createUnresolved(aHostname, aPort);
+			}
+			else
+			{
+				address = new InetSocketAddress(aHostname, aPort);
+			}
 		}
 		else
 		{

--- a/src/main/java/com/ircclouds/irc/api/comms/SocketChannelConnection.java
+++ b/src/main/java/com/ircclouds/irc/api/comms/SocketChannelConnection.java
@@ -25,15 +25,19 @@ public class SocketChannelConnection implements IConnection
 	{
 		if (channel == null || !channel.isConnected())
 		{
+			final InetSocketAddress address;
 			if (aProxy != null && aProxy.type() == Proxy.Type.SOCKS)
 			{
+				// FIXME how to determine whether to resolve immediately or use SOCKS5 proxy resolve feature
 				channel = new ProxiedSocketChannel(aProxy);
+				address = InetSocketAddress.createUnresolved(aHostname, aPort);
 			}
 			else
 			{
 				channel = SocketChannel.open();
+				address = new InetSocketAddress(aHostname, aPort);
 			}
-			return channel.connect(new InetSocketAddress(aHostname, aPort));
+			return channel.connect(address);
 		}
 		else
 		{

--- a/src/main/java/com/ircclouds/irc/api/comms/SocketChannelConnection.java
+++ b/src/main/java/com/ircclouds/irc/api/comms/SocketChannelConnection.java
@@ -7,10 +7,12 @@ import java.nio.channels.*;
 
 import javax.net.ssl.*;
 
+import nl.dannyvanheumen.nio.*;
+
 public class SocketChannelConnection implements IConnection
 {
 	private SocketChannel channel;
-	private ByteBuffer buffer = ByteBuffer.allocate(2048);
+	private final ByteBuffer buffer = ByteBuffer.allocate(2048);
 
 	@Override
 	public int write(String aMessage) throws IOException
@@ -19,11 +21,19 @@ public class SocketChannelConnection implements IConnection
 	}
 
 	@Override
-	public boolean open(String aHostname, int aPort, SSLContext aCtx) throws IOException
+	public boolean open(String aHostname, int aPort, SSLContext aCtx, Proxy aProxy) throws IOException
 	{
 		if (channel == null || !channel.isConnected())
 		{
-			return (channel = SocketChannel.open()).connect(new InetSocketAddress(aHostname, aPort));
+			if (aProxy != null && aProxy.type() == Proxy.Type.SOCKS)
+			{
+				channel = new ProxiedSocketChannel(aProxy);
+			}
+			else
+			{
+				channel = SocketChannel.open();
+			}
+			return channel.connect(new InetSocketAddress(aHostname, aPort));
 		}
 		else
 		{

--- a/src/main/java/com/ircclouds/irc/api/comms/SocketChannelConnection.java
+++ b/src/main/java/com/ircclouds/irc/api/comms/SocketChannelConnection.java
@@ -21,16 +21,22 @@ public class SocketChannelConnection implements IConnection
 	}
 
 	@Override
-	public boolean open(String aHostname, int aPort, SSLContext aCtx, Proxy aProxy) throws IOException
+	public boolean open(String aHostname, int aPort, SSLContext aCtx, Proxy aProxy, boolean resolveByProxy) throws IOException
 	{
 		if (channel == null || !channel.isConnected())
 		{
 			final InetSocketAddress address;
 			if (aProxy != null && aProxy.type() == Proxy.Type.SOCKS)
 			{
-				// FIXME how to determine whether to resolve immediately or use SOCKS5 proxy resolve feature
 				channel = new ProxiedSocketChannel(aProxy);
-				address = InetSocketAddress.createUnresolved(aHostname, aPort);
+				if (resolveByProxy)
+				{
+					address = InetSocketAddress.createUnresolved(aHostname, aPort);
+				}
+				else
+				{
+					address = new InetSocketAddress(aHostname, aPort);
+				}
 			}
 			else
 			{

--- a/src/main/java/com/ircclouds/irc/api/domain/IRCServer.java
+++ b/src/main/java/com/ircclouds/irc/api/domain/IRCServer.java
@@ -18,6 +18,7 @@ public class IRCServer implements ISource
 	private final int port;
 	private final Boolean isSSL;
 	private final Proxy proxy;
+	private final boolean resolveByProxy;
 
 	public IRCServer(String aHostname)
 	{
@@ -38,30 +39,32 @@ public class IRCServer implements ISource
 		password = "";
 		isSSL = aSSLServer;
 		proxy = null;
+		resolveByProxy = false;
 	}
 
 	public IRCServer(String aHostname, int aPort)
 	{
-		this(aHostname, aPort, "", false, null);
+		this(aHostname, aPort, "", false, null, false);
 	}
 
 	public IRCServer(String aHostname, int aPort, Boolean aIsSSL)
 	{
-		this(aHostname, aPort, "", aIsSSL, null);
+		this(aHostname, aPort, "", aIsSSL, null, false);
 	}
 
 	public IRCServer(String aHostname, int aPort, String aPassword, Boolean aIsSSL)
 	{
-		this(aHostname, aPort, aPassword, aIsSSL, null);
+		this(aHostname, aPort, aPassword, aIsSSL, null, false);
 	}
 
-	public IRCServer(String aHostname, int aPort, String aPassword, Boolean aIsSSL, Proxy aProxy)
+	public IRCServer(String aHostname, int aPort, String aPassword, Boolean aIsSSL, Proxy aProxy, boolean aResolveByProxy)
 	{
 		hostname = aHostname;
 		port = aPort;
 		password = aPassword;
 		isSSL = aIsSSL;
 		proxy = aProxy;
+		resolveByProxy = aResolveByProxy;
 	}
 
 	public String getPassword()
@@ -87,6 +90,11 @@ public class IRCServer implements ISource
 	public Proxy getProxy()
 	{
 		return proxy;
+	}
+
+	public boolean isResolveByProxy()
+	{
+		return resolveByProxy;
 	}
 	
 	@Override

--- a/src/main/java/com/ircclouds/irc/api/domain/IRCServer.java
+++ b/src/main/java/com/ircclouds/irc/api/domain/IRCServer.java
@@ -1,6 +1,7 @@
 package com.ircclouds.irc.api.domain;
 
 import com.ircclouds.irc.api.domain.messages.interfaces.*;
+import java.net.Proxy;
 
 /**
  * 
@@ -12,10 +13,11 @@ public class IRCServer implements ISource
 	private static final int DEFAULT_IRC_SERVER_PORT = 6667;
 	private static final int DEFAULT_SSL_IRC_SERVER_PORT = 6697;
 
-	private String hostname;
-	private String password;
-	private int port = DEFAULT_IRC_SERVER_PORT;
-	private Boolean isSSL;
+	private final String hostname;
+	private final String password;
+	private final int port;
+	private final Boolean isSSL;
+	private final Proxy proxy;
 
 	public IRCServer(String aHostname)
 	{
@@ -30,30 +32,36 @@ public class IRCServer implements ISource
 		}
 		else
 		{
-			 port = DEFAULT_IRC_SERVER_PORT;
+			port = DEFAULT_IRC_SERVER_PORT;
 		}
-		
 		hostname = aHostname;
 		password = "";
 		isSSL = aSSLServer;
+		proxy = null;
 	}
 
 	public IRCServer(String aHostname, int aPort)
 	{
-		this(aHostname, aPort, "", false);
+		this(aHostname, aPort, "", false, null);
 	}
 
 	public IRCServer(String aHostname, int aPort, Boolean aIsSSL)
 	{
-		this(aHostname, aPort, "", aIsSSL);
+		this(aHostname, aPort, "", aIsSSL, null);
 	}
 
 	public IRCServer(String aHostname, int aPort, String aPassword, Boolean aIsSSL)
+	{
+		this(aHostname, aPort, aPassword, aIsSSL, null);
+	}
+
+	public IRCServer(String aHostname, int aPort, String aPassword, Boolean aIsSSL, Proxy aProxy)
 	{
 		hostname = aHostname;
 		port = aPort;
 		password = aPassword;
 		isSSL = aIsSSL;
+		proxy = aProxy;
 	}
 
 	public String getPassword()
@@ -75,7 +83,13 @@ public class IRCServer implements ISource
 	{
 		return isSSL;
 	}
+
+	public Proxy getProxy()
+	{
+		return proxy;
+	}
 	
+	@Override
 	public String toString()
 	{
 		return hostname;

--- a/src/main/java/com/ircclouds/irc/api/domain/SecureIRCServer.java
+++ b/src/main/java/com/ircclouds/irc/api/domain/SecureIRCServer.java
@@ -1,11 +1,13 @@
 package com.ircclouds.irc.api.domain;
 
+import java.net.*;
+
 import javax.net.ssl.*;
 
 public class SecureIRCServer extends IRCServer
 {
 	private SSLContext sslContext;
-	
+
 	public SecureIRCServer(String aHostname)
 	{
 		super(aHostname, true);
@@ -18,32 +20,46 @@ public class SecureIRCServer extends IRCServer
 
 	public SecureIRCServer(String aHostname, int aPort, String aPassword)
 	{
-		super(aHostname, aPort, aPassword, true);		
+		super(aHostname, aPort, aPassword, true);
 	}
-	
+
 	public SecureIRCServer(String aHostname, SSLContext aSSLContext)
 	{
 		super(aHostname, true);
-		
+
 		sslContext = aSSLContext;
 	}
-	
+
 	public SecureIRCServer(String aHostname, int aPort, SSLContext aSSLContext)
 	{
 		super(aHostname, aPort, "", true);
-		
-		sslContext = aSSLContext;
-	}	
 	
+		sslContext = aSSLContext;
+	}
+
+	public SecureIRCServer(String aHostname, int aPort, SSLContext aSSLContext, Proxy aProxy)
+	{
+		super(aHostname, aPort, "", true, aProxy);
+
+		sslContext = aSSLContext;
+	}
+
 	public SecureIRCServer(String aHostname, int aPort, String aPassword, SSLContext aSSLContext)
 	{
 		super(aHostname, aPort, aPassword, true);
-		
+
 		sslContext = aSSLContext;
-	}	
-	
+	}
+
+	public SecureIRCServer(String aHostname, int aPort, String aPassword, SSLContext aSSLContext, Proxy aProxy)
+	{
+		super(aHostname, aPort, aPassword, true, aProxy);
+
+		sslContext = aSSLContext;
+	}
+
 	public SSLContext getSSLContext()
 	{
-			return sslContext;		
+		return sslContext;
 	}
 }

--- a/src/main/java/com/ircclouds/irc/api/domain/SecureIRCServer.java
+++ b/src/main/java/com/ircclouds/irc/api/domain/SecureIRCServer.java
@@ -37,9 +37,9 @@ public class SecureIRCServer extends IRCServer
 		sslContext = aSSLContext;
 	}
 
-	public SecureIRCServer(String aHostname, int aPort, SSLContext aSSLContext, Proxy aProxy)
+	public SecureIRCServer(String aHostname, int aPort, SSLContext aSSLContext, Proxy aProxy, boolean aResolveByProxy)
 	{
-		super(aHostname, aPort, "", true, aProxy);
+		super(aHostname, aPort, "", true, aProxy, aResolveByProxy);
 
 		sslContext = aSSLContext;
 	}
@@ -51,9 +51,9 @@ public class SecureIRCServer extends IRCServer
 		sslContext = aSSLContext;
 	}
 
-	public SecureIRCServer(String aHostname, int aPort, String aPassword, SSLContext aSSLContext, Proxy aProxy)
+	public SecureIRCServer(String aHostname, int aPort, String aPassword, SSLContext aSSLContext, Proxy aProxy, boolean aResolveByProxy)
 	{
-		super(aHostname, aPort, aPassword, true, aProxy);
+		super(aHostname, aPort, aPassword, true, aProxy, aResolveByProxy);
 
 		sslContext = aSSLContext;
 	}

--- a/src/main/java/nl/dannyvanheumen/nio/ProxiedSocketChannel.java
+++ b/src/main/java/nl/dannyvanheumen/nio/ProxiedSocketChannel.java
@@ -1,0 +1,391 @@
+/*
+ * Copyright 2015 Danny van Heumen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package nl.dannyvanheumen.nio;
+
+import java.io.*;
+import java.net.*;
+import java.nio.*;
+import java.nio.channels.*;
+import java.nio.channels.spi.*;
+import java.util.*;
+
+/**
+ * Alternative implementation of the SocketChannel interface that includes
+ * support for proxies. The implementation currently only supports
+ * <em>blocking</em> behavior.
+ *
+ * TODO implement non-blocking implementation and option to switch (consisting
+ * of non-blocking connect, read, write)
+ *
+ * @author Danny van Heumen
+ */
+public class ProxiedSocketChannel extends SocketChannel
+{
+	/**
+	 * Set of supported options.
+	 */
+	private static final Set<SocketOption<?>> SUPPORTED_OPTIONS;
+
+	static
+	{
+		final HashSet<SocketOption<?>> set = new HashSet<SocketOption<?>>();
+		set.add(StandardSocketOptions.SO_KEEPALIVE);
+		set.add(StandardSocketOptions.SO_RCVBUF);
+		set.add(StandardSocketOptions.SO_SNDBUF);
+		set.add(StandardSocketOptions.SO_REUSEADDR);
+		set.add(StandardSocketOptions.TCP_NODELAY);
+		set.add(StandardSocketOptions.SO_LINGER);
+		SUPPORTED_OPTIONS = Collections.unmodifiableSet(set);
+	}
+
+	/**
+	 * Constant for setting socket timeout to <em>infinite</em>.
+	 */
+	private static final int TIMEOUT_INFINITE = 0;
+
+	/**
+	 * Return code for EOF (end-of-file).
+	 */
+	private static final int EOF = -1;
+
+	/**
+	 * The underlying "classic" socket which does have proxy support.
+	 */
+	private final Socket socket;
+
+	/**
+	 * Create a proxied socket channel with provided proxy.
+	 *
+	 * @param proxy the required proxy configuration (null == Proxy.NO_PROXY)
+	 * @throws IOException
+	 */
+	public ProxiedSocketChannel(final Proxy proxy) throws IOException
+	{
+		super(SelectorProvider.provider());
+		if (proxy == null)
+		{
+			this.socket = new Socket(Proxy.NO_PROXY);
+		}
+		else
+		{
+			this.socket = new Socket(proxy);
+		}
+		// set timeout to 0 (infinite) since socketchannel generally does not
+		// time out (no SocketOption available either)
+		this.socket.setSoTimeout(TIMEOUT_INFINITE);
+	}
+
+	@Override
+	public SocketAddress getLocalAddress() throws IOException
+	{
+		return this.socket.getLocalSocketAddress();
+	}
+
+	@Override
+	public SocketChannel bind(final SocketAddress local) throws IOException
+	{
+		this.socket.bind(local);
+		return this;
+	}
+
+	@Override
+	public Set<SocketOption<?>> supportedOptions()
+	{
+		return SUPPORTED_OPTIONS;
+	}
+
+	@Override
+	public <T> T getOption(final SocketOption<T> option) throws IOException
+	{
+		if (StandardSocketOptions.SO_KEEPALIVE.equals(option))
+		{
+			return (T) StandardSocketOptions.SO_KEEPALIVE.type().cast(this.socket.getKeepAlive());
+		}
+		else if (StandardSocketOptions.SO_RCVBUF.equals(option))
+		{
+			return (T) StandardSocketOptions.SO_RCVBUF.type().cast(this.socket.getReceiveBufferSize());
+		}
+		else if (StandardSocketOptions.SO_SNDBUF.equals(option))
+		{
+			return (T) StandardSocketOptions.SO_SNDBUF.type().cast(this.socket.getSendBufferSize());
+		}
+		else if (StandardSocketOptions.SO_REUSEADDR.equals(option))
+		{
+			return (T) StandardSocketOptions.SO_REUSEADDR.type().cast(this.socket.getReuseAddress());
+		}
+		else if (StandardSocketOptions.TCP_NODELAY.equals(option))
+		{
+			return (T) StandardSocketOptions.TCP_NODELAY.type().cast(this.socket.getTcpNoDelay());
+		}
+		else if (StandardSocketOptions.SO_LINGER.equals(option))
+		{
+			return (T) StandardSocketOptions.SO_LINGER.type().cast(this.socket.getSoLinger());
+		}
+		throw new IllegalArgumentException("Unsupported option specified.");
+	}
+
+	@Override
+	public <T> SocketChannel setOption(final SocketOption<T> option, final T value)
+			throws IOException
+	{
+		if (StandardSocketOptions.SO_KEEPALIVE.equals(option))
+		{
+			final Class<Boolean> keepaliveType = StandardSocketOptions.SO_KEEPALIVE.type();
+			this.socket.setKeepAlive(keepaliveType.cast(value));
+		}
+		else if (StandardSocketOptions.SO_RCVBUF.equals(option))
+		{
+			final Class<Integer> rcvbufType = StandardSocketOptions.SO_RCVBUF.type();
+			this.socket.setReceiveBufferSize(rcvbufType.cast(value));
+		}
+		else if (StandardSocketOptions.SO_SNDBUF.equals(option)) {
+			final Class<Integer> sndbufType = StandardSocketOptions.SO_SNDBUF.type();
+			this.socket.setSendBufferSize(sndbufType.cast(value));
+		}
+		else if (StandardSocketOptions.SO_REUSEADDR.equals(option))
+		{
+			final Class<Boolean> reuseType = StandardSocketOptions.SO_REUSEADDR.type();
+			this.socket.setReuseAddress(reuseType.cast(value));
+		}
+		else if (StandardSocketOptions.TCP_NODELAY.equals(option))
+		{
+			final Class<Boolean> nodelayType = StandardSocketOptions.TCP_NODELAY.type();
+			this.socket.setTcpNoDelay(nodelayType.cast(value));
+		}
+		else if (StandardSocketOptions.SO_LINGER.equals(option))
+		{
+			final Class<Integer> lingerType = StandardSocketOptions.SO_LINGER.type();
+			final Integer lingerValue = lingerType.cast(value);
+			final boolean enabled = lingerValue >= 0;
+			this.socket.setSoLinger(enabled, lingerValue);
+		}
+		throw new IllegalArgumentException("Unsupported option specified.");
+	}
+
+	@Override
+	public SocketChannel shutdownInput() throws IOException
+	{
+		// FIXME synchronize on InputStream before shutting down?
+		this.socket.shutdownInput();
+		return this;
+	}
+
+	@Override
+	public SocketChannel shutdownOutput() throws IOException
+	{
+		// FIXME synchronize on OutputStream before shutting down?
+		this.socket.shutdownOutput();
+		return this;
+	}
+
+	@Override
+	public Socket socket()
+	{
+		return this.socket;
+	}
+
+	@Override
+	public boolean isConnected()
+	{
+		return this.socket.isConnected();
+	}
+
+	@Override
+	public boolean isConnectionPending()
+	{
+		return false;
+	}
+
+	@Override
+	public boolean connect(final SocketAddress remote) throws IOException
+	{
+		this.socket.connect(remote);
+		return true;
+	}
+
+	@Override
+	public boolean finishConnect() throws IOException
+	{
+		return this.socket.isConnected();
+	}
+
+	@Override
+	public SocketAddress getRemoteAddress() throws IOException
+	{
+		return this.socket.getRemoteSocketAddress();
+	}
+
+	@Override
+	public int read(final ByteBuffer dst) throws IOException
+	{
+		final InputStream input = this.socket.getInputStream();
+		synchronized (input)
+		{
+			return readBlocking(input, dst);
+		}
+	}
+
+	/**
+	 * Read from provided input stream in blocking fashion.
+	 *
+	 * NOTE: assumes that calling thread is already <em>synchronized</em> on
+	 * input stream!
+	 *
+	 * @param input the SYNCHRONIZED input stream
+	 * @param dst destination buffer
+	 * @return returns number of bytes read
+	 * @throws IOException in case of IOException
+	 */
+	private int readBlocking(final InputStream input, final ByteBuffer dst) throws IOException
+	{
+		final byte[] buffer = new byte[dst.remaining()];
+		final int size = input.read(buffer);
+		if (size > 0)
+		{
+			dst.put(buffer, 0, size);
+		}
+		return size;
+	}
+
+	@Override
+	public long read(final ByteBuffer[] dsts, final int offset, final int length)
+			throws IOException
+	{
+		final InputStream input = this.socket.getInputStream();
+		synchronized (input)
+		{
+			return readBlocking(input, dsts, offset, length);
+		}
+	}
+
+	/**
+	 * Read from provided input stream in blocking fashion.
+	 *
+	 * NOTE: assumes that calling thread is already <em>synchronized</em> on
+	 * input stream!
+	 *
+	 * @param input the SYNCHRONIZED input stream
+	 * @param dsts the array of destination buffers
+	 * @param offset the offset for first available buffer
+	 * @param length the number of buffers to use
+	 * @return returns number of bytes read
+	 * @throws IOException
+	 */
+	private long readBlocking(final InputStream input, final ByteBuffer[] dsts, final int offset, final int length) throws IOException
+	{
+		int total = 0;
+		for (int i = offset; i < offset + length; i++)
+		{
+			final int size = readBlocking(input, dsts[i]);
+			if (size == EOF)
+			{
+				if (total == 0)
+				{
+					// Very first response is EOF. Signal EOF to reader.
+					return EOF;
+				}
+				else
+				{
+					// EOF is not very first data read, so break and return
+					// whatever we have read so far.
+					break;
+				}
+			}
+			total += size;
+		}
+		return total;
+	}
+
+	@Override
+	public int write(final ByteBuffer src) throws IOException
+	{
+		final OutputStream output = this.socket.getOutputStream();
+		synchronized (output)
+		{
+			return writeBlocking(output, src);
+		}
+	}
+
+	/**
+	 * Write to provided output stream in blocking fashion.
+	 *
+	 * NOTE: assumes that calling thread is already synchronized on output
+	 * stream!
+	 *
+	 * @param output the SYNCHRONIZED output stream
+	 * @param src the source
+	 * @return returns number of bytes written
+	 * @throws IOException in case of exceptions
+	 */
+	private int writeBlocking(final OutputStream output, final ByteBuffer src) throws IOException
+	{
+		final byte[] buffer = new byte[src.remaining()];
+		src.get(buffer);
+		output.write(buffer);
+		return buffer.length;
+	}
+
+	@Override
+	public long write(final ByteBuffer[] srcs, final int offset, final int length)
+			throws IOException
+	{
+		final OutputStream output = this.socket.getOutputStream();
+		synchronized (output)
+		{
+			return writeBlocking(output, srcs, offset, length);
+		}
+	}
+
+	/**
+	 * Write to provided output stream in blocking fashion.
+	 *
+	 * NOTE: assumes that calling thread is already <em>synchronized</em> on
+	 * output stream!
+	 *
+	 * @param output the SYNCHRONIZED output stream
+	 * @param srcs the sources
+	 * @param offset the offset for the initial src buffer
+	 * @param length the number of src buffers available
+	 * @return returns number of bytes written
+	 * @throws IOException in case of exceptions
+	 */
+	private long writeBlocking(final OutputStream output, final ByteBuffer[] srcs, final int offset, final int length) throws IOException
+	{
+		int total = 0;
+		for (int i = offset; i < offset + length; i++)
+		{
+			total += writeBlocking(output, srcs[i]);
+		}
+		return total;
+	}
+
+	@Override
+	protected void implCloseSelectableChannel() throws IOException
+	{
+		this.socket.close();
+	}
+
+	@Override
+	protected void implConfigureBlocking(final boolean block) throws IOException
+	{
+		if (block)
+		{
+			return;
+		}
+		throw new UnsupportedOperationException("Non-blocking mode is not supported yet.");
+	}
+}

--- a/src/test/java/com/ircclouds/irc/api/comms/MockConnectionImpl.java
+++ b/src/test/java/com/ircclouds/irc/api/comms/MockConnectionImpl.java
@@ -1,6 +1,7 @@
 package com.ircclouds.irc.api.comms;
 
 import java.io.*;
+import java.net.*;
 import java.nio.*;
 
 import javax.net.ssl.*;
@@ -19,7 +20,7 @@ public class MockConnectionImpl implements IConnection
 	}
 	
 	@Mock
-	public boolean open(String aHostname, int aPort, SSLContext aCtx) throws IOException
+	public boolean open(String aHostname, int aPort, SSLContext aCtx, Proxy aProxy) throws IOException
 	{
 		InputStream _resourceAsStream = MockConnectionImpl.class.getResourceAsStream(filename);
 		if (_resourceAsStream != null)

--- a/src/test/java/com/ircclouds/irc/api/comms/MockConnectionImpl.java
+++ b/src/test/java/com/ircclouds/irc/api/comms/MockConnectionImpl.java
@@ -20,7 +20,7 @@ public class MockConnectionImpl implements IConnection
 	}
 	
 	@Mock
-	public boolean open(String aHostname, int aPort, SSLContext aCtx, Proxy aProxy) throws IOException
+	public boolean open(String aHostname, int aPort, SSLContext aCtx, Proxy aProxy, boolean aResolveByProxy) throws IOException
 	{
 		InputStream _resourceAsStream = MockConnectionImpl.class.getResourceAsStream(filename);
 		if (_resourceAsStream != null)


### PR DESCRIPTION
SOCKS 5 proxy support including deferring DNS domain name resolving to proxy.

This includes a custom SocketChannel implementation that utilizes a Socket internally for its proxy support. Non-blocking behaviour is not implemented yet, but was not used by irc-api anyways, so it does not degrade features anyway.
I have included the implementation directly in the pull request. Let me know if this is a problem for you.

Please have a look at this. I am not suggesting you merge the PR as is. I'm open to suggestions. (Unless rebasing failed, this should be in fully workable form.)